### PR TITLE
Make time limits for search queries configurable

### DIFF
--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -33,15 +33,15 @@ configs/
 
 ## CommonConfig
 
-| Key Name            | Datatype | Example                        | Description                                                                                                                     |
-|:--------------------|:--------:|:-------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
-| dxApiBasePath       |  String  | /auth/v1                       | API base path for DX AAA server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)          |
-| dxAuthBasePath      |  String  | /ngsi-ld/v1                    | API base path for DX rs-proxy-sever. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)      |
-| dxCatalogueBasePath |  String  | /iudx/cat/v1                   | API base path for DX Catalogue server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)    |
-| catServerHost       |  String  | api.cat-test.iudx.io           | Host name of DX Catalogue server for fetching the information of resources, resource groups                                     |
-| catServerPort       | integer  | 443                            | Port number to access HTTPS APIs of Catalogue Server                                                                            |
-| timeLimit           |  String  | "test,2020-10-22T00:00:00Z,20" | Contains three parts separated by commas: the deployment type, a date-time stamp, and the maximum number of allowed query days. |
-| timeLimitForAsync   | integer  | 365                            | No of time limit (in days) for asynchronous search queries.                                                                     |
+| Key Name            | Datatype | Example                        | Description                                                                                                                             |
+|:--------------------|:--------:|:-------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
+| dxApiBasePath       |  String  | /auth/v1                       | API base path for DX AAA server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)                  |
+| dxAuthBasePath      |  String  | /ngsi-ld/v1                    | API base path for DX rs-proxy-sever. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)              |
+| dxCatalogueBasePath |  String  | /iudx/cat/v1                   | API base path for DX Catalogue server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)            |
+| catServerHost       |  String  | api.cat-test.iudx.io           | Host name of DX Catalogue server for fetching the information of resources, resource groups                                             |
+| catServerPort       | integer  | 443                            | Port number to access HTTPS APIs of Catalogue Server                                                                                    |
+| timeLimit           |  String  | "test,2020-10-22T00:00:00Z,20" | Contains three comma-separated parts: deployment type (e.g., test or production), a date-time stamp, and the maximum allowed query days | |          |                                | it could be test or production                                                                                                          |
+| timeLimitForAsync   | integer  | 365                            | No of time limit (in days) for asynchronous search queries.                                                                             |
 
 ## Api Server Verticle
 

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -3,8 +3,12 @@
 </p>
 
 # Modules
-This document contains the information of the configurations to setup various services and dependencies in order to bring up the DX Resource Server. 
-Please find the example configuration file [here](https://github.com/datakaveri/iudx-resource-server/blob/master/example-configs/configs/config-dev.json). While running the server, make a copy of sample configs directory and add appropriate values to all files.
+
+This document contains the information of the configurations to setup various services and dependencies in order to
+bring up the DX Resource Server.
+Please find the example configuration
+file [here](https://github.com/datakaveri/iudx-resource-server/blob/master/example-configs/configs/config-dev.json).
+While running the server, make a copy of sample configs directory and add appropriate values to all files.
 
 ```console
  cp -r example-configs/* .
@@ -19,6 +23,25 @@ configs/
 └── keystore.p12
 ```
 
+## Other Configuration
+
+| Key Name   | Value Datatype | Value Example   | Description                                                 |
+|:-----------|:--------------:|:----------------|:------------------------------------------------------------|
+| version    |     Float      | 1.0             | config version                                              |
+| zookeepers |     Array      | zookeeper       | zookeeper configuration to deploy clustered vert.x instance |
+| clusterId  |     String     | iudx-rs-cluster | cluster id to deploy clustered vert.x instance              |
+
+## CommonConfig
+
+| Key Name            | Datatype | Example                        | Description                                                                                                                     |
+|:--------------------|:--------:|:-------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| dxApiBasePath       |  String  | /auth/v1                       | API base path for DX AAA server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)          |
+| dxAuthBasePath      |  String  | /ngsi-ld/v1                    | API base path for DX rs-proxy-sever. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)      |
+| dxCatalogueBasePath |  String  | /iudx/cat/v1                   | API base path for DX Catalogue server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)    |
+| catServerHost       |  String  | api.cat-test.iudx.io           | Host name of DX Catalogue server for fetching the information of resources, resource groups                                     |
+| catServerPort       | integer  | 443                            | Port number to access HTTPS APIs of Catalogue Server                                                                            |
+| timeLimit           |  String  | "test,2020-10-22T00:00:00Z,20" | Contains three parts separated by commas: the deployment type, a date-time stamp, and the maximum number of allowed query days. |
+| timeLimitForAsync   | integer  | 365                            | No of time limit (in days) for asynchronous search queries.                                                                     |
 
 ## Api Server Verticle
 
@@ -28,19 +51,6 @@ configs/
 | verticleInstances |    integer     | 8             | Number of instances required for verticles                               |
 | httpPort          |    integer     | 8443          | Port for running the instance DX Resource Server                         |
 | ssl               |    boolean     | true          | Enable or Disable secure sockets                                         |
-
-## Other Configuration
-
-| Key Name                         | Value Datatype | Value Example                        | Description                                                                                                                  |
-|:---------------------------------|:--------------:|:-------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| version                          |     Float      | 1.0                                  | config version                                                                                                               |
-| zookeepers                       |     Array      | zookeeper                            | zookeeper configuration to deploy clustered vert.x instance                                                                  |
-| clusterId                        |     String     | iudx-rs-cluster                      | cluster id to deploy clustered vert.x instance                                                                               |
-| commonConfig.dxApiBasePath       |     String     | /ngsi-ld/v1                          | API base path for DX Resource Server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)  |
-| commonConfig.dxCatalogueBasePath |     String     | /iudx/cat/v1                         | API base path for DX Catalogue server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/) |
-| commonConfig.dxAuthBasePath      |     String     | /auth/v1                             | API base path for DX AAA server. Reference : [link](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)       |
-| commonConfig.catServerHost       |     String     | api.cat-test.iudx.io                 | Host name of DX Catalogue server for fetching the information of resources, resource groups                                  |
-| commonConfig.catServerPort       |    integer     | 443                                  | Port number to access HTTPS APIs of Catalogue Server                                                                         |
 
 ## Database Verticle
 
@@ -84,7 +94,6 @@ configs/
 | brokerAmqpIp             |     String     | localhost        | AMQ IP of data broker                                                                                  |                                                                                                        |
 | brokerAmqpPort           |    integer     | 23456            | AMQ Port of data broker                                                                                |                                                                                                        |
 
-
 ## Authentication Verticle
 
 | Key Name          | Value Datatype | Value Example | Description                                                                 |
@@ -98,10 +107,10 @@ configs/
 
 ## Metering Verticle
 
-| Key Name                 | Value Datatype | Value Example | Description                                                                                            |
-|:-------------------------|:--------------:|:--------------|:-------------------------------------------------------------------------------------------------------|
-| isWorkerVerticle         |    boolean     | false         | To check if worker verticle needs to be deployed for blocking operations                               |
-| verticleInstances        |    integer     | 1             | Number of instances required for verticles                                                             |
+| Key Name          | Value Datatype | Value Example | Description                                                              |
+|:------------------|:--------------:|:--------------|:-------------------------------------------------------------------------|
+| isWorkerVerticle  |    boolean     | false         | To check if worker verticle needs to be deployed for blocking operations |
+| verticleInstances |    integer     | 1             | Number of instances required for verticles                               |
 
 ## Latest Verticle
 
@@ -135,10 +144,10 @@ configs/
 
 ## Cache Verticle
 
-| Key Name           | Value Datatype | Value Example                             | Description                                     |
-|:-------------------|:---------------|:------------------------------------------|:------------------------------------------------|
-| isWorkerVerticle   | boolean        | false                                     | Indicates if the verticle is a worker verticle  |
-| verticleInstances  | integer        | 1                                         | Number of instances for this verticle           |
+| Key Name          | Value Datatype | Value Example | Description                                    |
+|:------------------|:---------------|:--------------|:-----------------------------------------------|
+| isWorkerVerticle  | boolean        | false         | Indicates if the verticle is a worker verticle |
+| verticleInstances | integer        | 1             | Number of instances for this verticle          |
 
 ## Async Verticle
 

--- a/example-configs/configs/config-dev.json
+++ b/example-configs/configs/config-dev.json
@@ -9,7 +9,9 @@
     "dxCatalogueBasePath": "/iudx/cat/v1",
     "dxAuthBasePath": "/auth/v1",
     "catServerHost": "",
-    "catServerPort": 443
+    "catServerPort": 443,
+    "timeLimit": "test,2020-10-22T00:00:00Z,20",
+    "timeLimitForAsync": 365
   },
   "modules": [
     {

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -65,8 +65,9 @@ public class AsyncRestApi {
   private AsyncService asyncService;
   private EncryptionService encryptionService;
   private Api api;
+  private int timeLimitForAsync;
 
-  AsyncRestApi(Vertx vertx, Router router, Api api) {
+  AsyncRestApi(Vertx vertx, Router router, Api api, int timeLimitForAsync) {
     this.vertx = vertx;
     this.router = router;
     this.databroker = DataBrokerService.createProxy(vertx, BROKER_SERVICE_ADDRESS);
@@ -76,6 +77,7 @@ public class AsyncRestApi {
     this.postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
     this.encryptionService = EncryptionService.createProxy(vertx, ENCRYPTION_SERVICE_ADDRESS);
     this.api = api;
+    this.timeLimitForAsync = timeLimitForAsync;
   }
 
   Router init() {
@@ -127,7 +129,7 @@ public class AsyncRestApi {
         validationHandler -> {
           if (validationHandler.succeeded()) {
             NgsildQueryParams ngsildquery = new NgsildQueryParams(params);
-            QueryMapper queryMapper = new QueryMapper(routingContext);
+            QueryMapper queryMapper = new QueryMapper(routingContext, timeLimitForAsync);
             JsonObject json = queryMapper.toJson(ngsildquery, true, true);
             json.put(JSON_INSTANCEID, instanceId);
             LOGGER.debug("Info: IUDX json query;" + json);

--- a/src/main/java/iudx/resource/server/apiserver/query/QueryMapper.java
+++ b/src/main/java/iudx/resource/server/apiserver/query/QueryMapper.java
@@ -8,9 +8,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import iudx.resource.server.apiserver.exceptions.DxRuntimeException;
-import iudx.resource.server.apiserver.util.Constants;
 import iudx.resource.server.common.HttpStatusCode;
-import iudx.resource.server.common.ResponseUrn;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -30,9 +28,11 @@ public class QueryMapper {
   private boolean isResponseFilter = false;
   private boolean isAttributeSearch = false;
   private RoutingContext context;
+  private int timeLimit;
 
-  public QueryMapper(RoutingContext context) {
+  public QueryMapper(RoutingContext context, int timeLimit) {
     this.context = context;
+    this.timeLimit = timeLimit;
   }
 
   public JsonObject toJson(NgsildQueryParams params, boolean isTemporal) {
@@ -82,9 +82,7 @@ public class QueryMapper {
         } else {
           json.put(JSON_GEOMETRY, params.getGeometry());
           json.put(JSON_COORDINATES, params.getCoordinates());
-          json.put(
-              JSON_GEOREL,
-              getOrDefault(params.getGeoRel().getRelation(), JSON_WITHIN));
+          json.put(JSON_GEOREL, getOrDefault(params.getGeoRel().getRelation(), JSON_WITHIN));
           if (params.getGeoRel().getMaxDistance() != null) {
             json.put(JSON_MAXDISTANCE, params.getGeoRel().getMaxDistance());
           } else if (params.getGeoRel().getMinDistance() != null) {
@@ -116,10 +114,7 @@ public class QueryMapper {
         json.put(JSON_TIMEREL, params.getTemporalRelation().getTemprel());
 
         isValidTimeInterval(
-            JSON_DURING,
-            json.getString(JSON_TIME),
-            json.getString(JSON_ENDTIME),
-            isAsyncQuery);
+            JSON_DURING, json.getString(JSON_TIME), json.getString(JSON_ENDTIME), isAsyncQuery);
       } else {
         json.put(JSON_TIME, params.getTemporalRelation().getTime().toString());
         json.put(JSON_TIMEREL, params.getTemporalRelation().getTemprel());
@@ -187,21 +182,20 @@ public class QueryMapper {
         this.context.fail(400, exc);
       }
     }
-    if (isAsyncQuery
-        && totalDaysAllowed > VALIDATION_MAX_DAYS_INTERVAL_ALLOWED_FOR_ASYNC) {
+    if (isAsyncQuery && totalDaysAllowed > timeLimit) {
       DxRuntimeException ex =
           new DxRuntimeException(
               BAD_REQUEST.getValue(),
               INVALID_TEMPORAL_PARAM_URN,
-              "time interval greater than 1 year is not allowed");
+              "time interval greater than " + timeLimit + " days is not allowed");
       this.context.fail(400, ex);
     }
-    if (!isAsyncQuery && totalDaysAllowed > VALIDATION_MAX_DAYS_INTERVAL_ALLOWED) {
+    if (!isAsyncQuery && totalDaysAllowed > timeLimit) {
       DxRuntimeException ex =
           new DxRuntimeException(
               BAD_REQUEST.getValue(),
               INVALID_TEMPORAL_PARAM_URN,
-              "time interval greater than 10 days is not allowed");
+              "time interval greater than " + timeLimit + " days is not allowed");
       this.context.fail(400, ex);
     }
   }

--- a/src/test/java/iudx/resource/server/apiserver/query/QueryMapperTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/query/QueryMapperTest.java
@@ -68,7 +68,7 @@ public class QueryMapperTest {
 
   @BeforeEach
   public void setup(Vertx vertx, VertxTestContext testContext) {
-    qm = new QueryMapper(context);
+    qm = new QueryMapper(context,10);
     testContext.completeNow();
   }
 


### PR DESCRIPTION
This PR introduces configurable time limits for async and normal queries. The allowed query days can now be managed directly through the config file.

**Note** : Updates to the config file require changes in Jenkins and master pipeline as well."